### PR TITLE
Add gitlab_nginx_listem_port variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Optional variables:
 *   `gitlab_url` (default: `http://gitlab.example.com`)
 *   `gitlab_ssh_port` (default: `22022`)
 *   `gitlab_monitoring_whitelist` (default: `127.0.0.0/8`)
+*   `gitlab_nginix_listen_port`
 
 An example of variables usage provided in *Example Playbook* section.
 
@@ -42,7 +43,8 @@ Example Playbook
     - role: yabusygin.gitlab
   vars:
     gitlab_image: gitlab/gitlab-ce:12.7.6-ce.0
-    gitlab_url: http://gitlab.test
+    gitlab_url: http://gitlab.test:8000
+    gitlab_nginix_listen_port: 80
     gitlab_ssh_port: 2222
     gitlab_monitoring_whitelist:
       - 127.0.0.0/8

--- a/molecule/port-forwarding/host_vars/instance.yml
+++ b/molecule/port-forwarding/host_vars/instance.yml
@@ -1,0 +1,6 @@
+---
+ansible_python_interpreter: python3
+
+gitlab_url: http://gitlab.test:8000
+gitlab_nginix_listen_port: 80
+gitlab_monitoring_whitelist: 0.0.0.0/0

--- a/molecule/port-forwarding/molecule.yml
+++ b/molecule/port-forwarding/molecule.yml
@@ -1,0 +1,25 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: docker
+lint:
+  name: yamllint
+platforms:
+  - name: instance
+    image: ${TEST_IMAGE}
+    command: ""
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+      - /var/lib/docker
+    keep_volumes: false
+    privileged: true
+    pre_build_image: true
+provisioner:
+  name: ansible
+  lint:
+    name: ansible-lint
+verifier:
+  name: testinfra
+  lint:
+    name: flake8

--- a/molecule/port-forwarding/playbook.yml
+++ b/molecule/port-forwarding/playbook.yml
@@ -1,0 +1,11 @@
+---
+- name: converge
+  hosts: instance
+  roles:
+    - role: gitlab
+  tasks:
+    - name: install HTTPie
+      pip:
+        name:
+          - httpie
+        state: present

--- a/molecule/port-forwarding/requirements.yml
+++ b/molecule/port-forwarding/requirements.yml
@@ -1,0 +1,3 @@
+---
+- src: yabusygin.docker
+  version: 2.2.2

--- a/molecule/port-forwarding/tests/test_default.py
+++ b/molecule/port-forwarding/tests/test_default.py
@@ -1,0 +1,39 @@
+import json
+import os
+import time
+
+import testinfra.utils.ansible_runner
+
+testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
+    os.environ['MOLECULE_INVENTORY_FILE']
+).get_hosts('instance')
+
+
+def test_health(host):
+    args = (
+        "http",
+        "--ignore-stdin",
+        "--check-status",
+        "--body",
+        "localhost/-/readiness?all=1",
+    )
+    retries = 120
+    while retries > 0:
+        cmd = host.run(
+            command=" ".join(args),
+        )
+        if cmd.rc == 0:
+            break
+        retries -= 1
+        time.sleep(1)
+    assert retries > 0
+
+    response = json.loads(s=cmd.stdout)
+    assert response["status"] == "ok"
+    assert response["cache_check"][0]["status"] == "ok"
+    assert response["db_check"][0]["status"] == "ok"
+    assert response["gitaly_check"][0]["status"] == "ok"
+    assert response["master_check"][0]["status"] == "ok"
+    assert response["queues_check"][0]["status"] == "ok"
+    assert response["redis_check"][0]["status"] == "ok"
+    assert response["shared_state_check"][0]["status"] == "ok"

--- a/templates/gitlab.rb.j2
+++ b/templates/gitlab.rb.j2
@@ -1,4 +1,7 @@
 external_url '{{ gitlab_url }}'
+{% if gitlab_nginix_listen_port is defined %}
+nginx['listen_port'] = {{ gitlab_nginix_listen_port }}
+{% endif %}
 gitlab_rails['gitlab_shell_ssh_port'] = {{ gitlab_ssh_port }}
 {% if gitlab_monitoring_whitelist is defined %}
     {% if gitlab_monitoring_whitelist is string %}

--- a/templates_tests/config_nginx_listen_port/gitlab.rb
+++ b/templates_tests/config_nginx_listen_port/gitlab.rb
@@ -1,0 +1,3 @@
+external_url 'http://gitlab.example.com'
+nginx['listen_port'] = 80
+gitlab_rails['gitlab_shell_ssh_port'] = 22022

--- a/templates_tests/config_nginx_listen_port/test.py
+++ b/templates_tests/config_nginx_listen_port/test.py
@@ -1,0 +1,47 @@
+import unittest
+import pathlib
+try:
+    import importlib.resources as resources
+except ImportError:
+    import importlib_resources as resources
+
+from ..utils import (
+    resolve_path,
+    render_role_template,
+    yaml_parse,
+)
+
+
+_ROLE_PATH = resolve_path(
+    base_path=pathlib.Path(__file__),
+    relative_path=pathlib.Path("..", ".."),
+)
+_TEMPLATE_VARIABLES_FILENAME = "vars.yml"
+
+_TEMPLATE_FILENAME = "gitlab.rb.j2"
+_EXPECTED_RESULT_FILENAME = "gitlab.rb"
+
+
+class RenderFromTemplate(unittest.TestCase):
+
+    def test(self):
+        expect = resources.read_text(
+            package=__package__,
+            resource=_EXPECTED_RESULT_FILENAME,
+        )
+        variables = None
+        if resources.is_resource(
+                package=__package__,
+                name=_TEMPLATE_VARIABLES_FILENAME):
+            variables = yaml_parse(
+                data=resources.read_text(
+                    package=__package__,
+                    resource=_TEMPLATE_VARIABLES_FILENAME,
+                ),
+            )
+        actual = render_role_template(
+            role_path=_ROLE_PATH,
+            template_filename=_TEMPLATE_FILENAME,
+            variables=variables,
+        )
+        self.assertEqual(expect, actual)

--- a/templates_tests/config_nginx_listen_port/vars.yml
+++ b/templates_tests/config_nginx_listen_port/vars.yml
@@ -1,0 +1,2 @@
+---
+gitlab_nginix_listen_port: 80


### PR DESCRIPTION
Add `gitlab_nginx_listem_port ` variable. The variable explicitly specifies port that bundled Nginix should listen.

Closes #4.