### PR TITLE
Enable Docker userns-remap for Molecule tests and example playbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Example Playbook
   roles:
     - role: yabusygin.gitlab
   vars:
+    docker_userns_remap_enable: yes
     gitlab_image: gitlab/gitlab-ce:12.7.6-ce.0
     gitlab_external_url: http://gitlab.test:8000
     gitlab_nginix_listen_port: 80

--- a/molecule/default/host_vars/instance.yml
+++ b/molecule/default/host_vars/instance.yml
@@ -1,4 +1,6 @@
 ---
 ansible_python_interpreter: python3
 
+docker_userns_remap_enable: yes
+
 gitlab_rails_monitoring_whitelist: 0.0.0.0/0

--- a/molecule/port-forwarding/host_vars/instance.yml
+++ b/molecule/port-forwarding/host_vars/instance.yml
@@ -1,6 +1,8 @@
 ---
 ansible_python_interpreter: python3
 
+docker_userns_remap_enable: yes
+
 gitlab_external_url: http://gitlab.test:8000
 gitlab_nginix_listen_port: 80
 gitlab_rails_monitoring_whitelist: 0.0.0.0/0


### PR DESCRIPTION
Closes #11.