### PR TITLE
Fix multiple test workflow issues

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,6 @@ jobs:
         image:
           - "geerlingguy/docker-debian9-ansible:latest"
           - "geerlingguy/docker-debian10-ansible:latest"
-          - "geerlingguy/docker-ubuntu1604-ansible:latest"
           - "geerlingguy/docker-ubuntu1804-ansible:latest"
         scenario:
           - custom-userns-remap-user

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -12,7 +12,6 @@ galaxy_info:
         - stretch
     - name: Ubuntu
       versions:
-        - bionic
         - xenial
   galaxy_tags:
     - docker

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-ansible
+ansible>=2.9,<2.10
 Jinja2
 PyYAML
 importlib_resources

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,6 +7,7 @@
   file:
     path: /etc/docker-gitlab
     state: directory
+    mode: 0755
 
 - name: get userns-remap UID/GID ranges
   import_tasks: get-docker-userns-remap-info.yml


### PR DESCRIPTION
* Terminate Ubuntu 16.04 support.
* Fix Ansible Lint warning.
* Use Ansible 2.9 in test workflow.

Closes #39, closes #41.