### PR TITLE
Run release workflow only when a new tag is pushed

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,8 +2,6 @@
 name: release
 on:
   push:
-    branches:
-      - master
     tags:
       - "[0-9]+.[0-9]+.[0-9]+"
 jobs:


### PR DESCRIPTION
Closes #45.