### PR TITLE
Use version 3.0.0 of yabusygin.docker role

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,7 +396,12 @@ requirements, then it is recommended to enable
 [user namespace remapping feature][UsernsRemap]:
 
 ```yaml
-docker_userns_remap_enable: yes
+docker_config:
+  userns-remap: default
+  log-driver: json-file
+  log-opts:
+    max-size: 10m
+    max-file: "3"
 gitlab_userns_remap_enable: yes
 ```
 
@@ -453,7 +458,12 @@ With [yabusygin.docker][DockerRole] role:
     - import_role:
         name: yabusygin.docker
       vars:
-        docker_userns_remap_enable: yes
+        docker_config:
+          userns-remap: default
+          log-driver: json-file
+          log-opts:
+            max-size: 10m
+            max-file: "3"
 
     - import_role:
         name: yabusygin.gitlab

--- a/molecule/default/requirements.yml
+++ b/molecule/default/requirements.yml
@@ -1,3 +1,3 @@
 ---
 - src: yabusygin.docker
-  version: 2.2.2
+  version: 3.0.0

--- a/molecule/https/host_vars/instance.yml
+++ b/molecule/https/host_vars/instance.yml
@@ -1,7 +1,8 @@
 ---
 ansible_python_interpreter: python3
 
-docker_userns_remap_enable: yes
+docker_config:
+  userns-remap: default
 
 gitlab_userns_remap_enable: yes
 

--- a/molecule/https/requirements.yml
+++ b/molecule/https/requirements.yml
@@ -1,3 +1,3 @@
 ---
 - src: yabusygin.docker
-  version: 2.2.2
+  version: 3.0.0

--- a/molecule/smtp/requirements.yml
+++ b/molecule/smtp/requirements.yml
@@ -1,3 +1,3 @@
 ---
 - src: yabusygin.docker
-  version: 2.2.2
+  version: 3.0.0

--- a/molecule/userns_remap/host_vars/instance.yml
+++ b/molecule/userns_remap/host_vars/instance.yml
@@ -1,7 +1,8 @@
 ---
 ansible_python_interpreter: python3
 
-docker_userns_remap_enable: yes
+docker_config:
+  userns-remap: default
 
 gitlab_userns_remap_enable: yes
 

--- a/molecule/userns_remap/requirements.yml
+++ b/molecule/userns_remap/requirements.yml
@@ -1,3 +1,3 @@
 ---
 - src: yabusygin.docker
-  version: 2.2.2
+  version: 3.0.0


### PR DESCRIPTION
Examples and tests are updated to use version 3.0.0 of `yabusygin.docker` role.