### PR TITLE
Implement automated backups

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,0 +1,12 @@
+---
+# A workaround to bypass the following error:
+# internal-error: the role 'yabusygin.gitlab' was not found
+exclude_paths:
+  - molecule/default/converge.yml
+  - molecule/https/converge.yml
+  - molecule/s3_backup/converge.yml
+  - molecule/smtp/converge.yml
+  - molecule/userns_remap/converge.yml
+
+warn_list:
+  - fqcn-builtins

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,7 @@ jobs:
           - userns_remap
           - https
           - smtp
+          - s3_backup
     steps:
       - name: Check-out repository
         uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -388,6 +388,104 @@ Variable reference:
 
 [UsernsRemap]: https://docs.docker.com/engine/security/userns-remap/
 
+### Backup ###
+
+See [Gitlab documentation][Backup] for details.
+
+[Backup]: https://docs.gitlab.com/ee/raketasks/backup_restore.html
+
+#### Automated Backups ####
+
+Variable reference:
+
+*   `gitlab_backup_cron_enable` -- enable cron job that performs periodic
+    backups. Default value: `no`.
+
+*   `gitlab_backup_cron_minute` -- a "minute" field of cron command line.
+    Mandatory variable. See [`crontab(5)`][Crontab5].
+
+*   `gitlab_backup_cron_hour` -- a "hour" field of cron command line. Mandatory
+    variable. See [`crontab(5)`][Crontab5].
+
+*   `gitlab_backup_cron_day_of_month` -- a "day of month" field of cron command
+    line. Default value: `*`.
+
+*   `gitlab_backup_cron_month` -- a "month" field of cron command line. Default
+    value: `*`.
+
+*   `gitlab_backup_cron_day_of_week` -- a "day of week" field of cron command
+    line. Default value: `*`.
+
+[Crontab5]: https://man7.org/linux/man-pages/man5/crontab.5.html
+
+#### Uploading Backups to Remote Storage ####
+
+Only S3 compatible remote storage is currently supported.
+
+Variable reference:
+
+*   `gitlab_backup_upload_enable` -- enable uploading backups to remote storage.
+    Default value: `no`.
+
+*   `gitlab_backup_upload_type` -- remote storage type. Values: `s3`.
+
+*   `gitlab_backup_upload_s3_region` -- AWS [region][AWSRegion].
+
+    [AWSRegion]: https://docs.aws.amazon.com/general/latest/gr/glos-chap.html#region
+
+*   `gitlab_backup_upload_s3_bucket` -- S3 [bucket][AWSS3Bucket] to store backup
+    objects.
+
+    [AWSS3Bucket]: https://docs.aws.amazon.com/general/latest/gr/glos-chap.html#bucket
+
+*   `gitlab_backup_upload_s3_access_key_id` -- [access key ID][AWSAccessKeyID].
+
+    [AWSAccessKeyID]: https://docs.aws.amazon.com/general/latest/gr/glos-chap.html#accesskeyID
+
+*   `gitlab_backup_upload_s3_secret_access_key` -- [secret access key][AWSsecretAccessKey].
+
+    [AWSsecretAccessKey]: https://docs.aws.amazon.com/general/latest/gr/glos-chap.html#SecretAccessKey
+
+*   `gitlab_backup_upload_s3_endpoint` -- S3 compatible storage HTTP API endpoint.
+
+*   `gitlab_backup_upload_s3_path_style_enable` -- use path-style method for
+    accessing a bucket (see
+    [Methods for accessing a bucket][AWSS3AccessBucket]). Sets
+    `gitlab_rails['backup_upload_connection']['path_style']` value.
+
+    [AWSS3AccessBucket]: https://docs.aws.amazon.com/AmazonS3/latest/userguide/access-bucket-intro.html
+
+Example of uploading backups to Digital Ocean Spaces:
+
+```yaml
+gitlab_backup_upload_enable: yes
+gitlab_backup_upload_type: s3
+gitlab_backup_upload_s3_endpoint: https://ams3.digitaloceanspaces.com
+gitlab_backup_upload_s3_region: ams3
+gitlab_backup_upload_s3_bucket: my.s3.bucket
+gitlab_backup_upload_s3_access_key_id: AKIAKIAKI
+gitlab_backup_upload_s3_secret_access_key: secret123
+```
+
+The following configuration will be added:
+
+```ruby
+gitlab_rails['backup_upload_connection'] = {
+  'provider' => 'AWS',
+  'endpoint' => 'https://ams3.digitaloceanspaces.com',
+  'region' => 'ams3',
+  'aws_access_key_id' => 'AKIAKIAKI',
+  'aws_secret_access_key' => 'secret123'
+}
+gitlab_rails['backup_upload_remote_directory'] = 'my.s3.bucket'
+```
+
+#### Limit Lifetime of Local Backup Files ####
+
+Variable reference:
+
+*   `gitlab_backup_keep_time` -- sets `gitlab_rails['backup_keep_time']` value.
+
 Dependencies
 ------------
 
@@ -478,6 +576,20 @@ Customized setup:
         gitlab_email_smtp_user_auth_method: login
         gitlab_email_smtp_user_name: gitlab
         gitlab_email_smtp_user_password: Pa$$w0rD
+
+        gitlab_backup_cron_enable: yes
+        gitlab_backup_cron_minute: 0
+        gitlab_backup_cron_hour: 2
+
+        gitlab_backup_upload_enable: yes
+        gitlab_backup_upload_type: s3
+        gitlab_backup_upload_s3_endpoint: https://ams3.digitaloceanspaces.com
+        gitlab_backup_upload_s3_region: ams3
+        gitlab_backup_upload_s3_bucket: my.s3.bucket
+        gitlab_backup_upload_s3_access_key_id: AKIAKIAKI
+        gitlab_backup_upload_s3_secret_access_key: secret123
+
+        gitlab_backup_keep_time: 604800
 ```
 
 License

--- a/README.md
+++ b/README.md
@@ -427,22 +427,25 @@ Variable reference:
 *   `gitlab_backup_upload_enable` -- enable uploading backups to remote storage.
     Default value: `no`.
 
-*   `gitlab_backup_upload_type` -- remote storage type. Values: `s3`.
+*   `gitlab_backup_upload_type` -- remote storage type. Supported values: `s3`.
+    Default value: `s3`.
 
 *   `gitlab_backup_upload_s3_region` -- AWS [region][AWSRegion].
 
     [AWSRegion]: https://docs.aws.amazon.com/general/latest/gr/glos-chap.html#region
 
 *   `gitlab_backup_upload_s3_bucket` -- S3 [bucket][AWSS3Bucket] to store backup
-    objects.
+    objects. Mandatory variable.
 
     [AWSS3Bucket]: https://docs.aws.amazon.com/general/latest/gr/glos-chap.html#bucket
 
 *   `gitlab_backup_upload_s3_access_key_id` -- [access key ID][AWSAccessKeyID].
+    Mandatory variable.
 
     [AWSAccessKeyID]: https://docs.aws.amazon.com/general/latest/gr/glos-chap.html#accesskeyID
 
-*   `gitlab_backup_upload_s3_secret_access_key` -- [secret access key][AWSsecretAccessKey].
+*   `gitlab_backup_upload_s3_secret_access_key` --
+    [secret access key][AWSsecretAccessKey]. Mandatory variable.
 
     [AWSsecretAccessKey]: https://docs.aws.amazon.com/general/latest/gr/glos-chap.html#SecretAccessKey
 

--- a/README.md
+++ b/README.md
@@ -416,6 +416,12 @@ Variable reference:
 *   `gitlab_backup_cron_day_of_week` -- a "day of week" field of cron command
     line. Default value: `*`.
 
+*   `gitlab_backup_cron_docker_cmd` -- command that backup cron job uses to
+    invoke Docker Engine. Default: `docker`.
+
+*   `gitlab_backup_cron_docker_compose_cmd` -- command that backup cron job uses
+    to invoke Docker Compose. Default: `docker-compose`.
+
 [Crontab5]: https://man7.org/linux/man-pages/man5/crontab.5.html
 
 #### Uploading Backups to Remote Storage ####

--- a/README.md
+++ b/README.md
@@ -589,6 +589,8 @@ Customized setup:
         gitlab_backup_cron_enable: yes
         gitlab_backup_cron_minute: 0
         gitlab_backup_cron_hour: 2
+        gitlab_backup_cron_docker_cmd: /usr/bin/docker
+        gitlab_backup_cron_docker_compose_cmd: /usr/local/bin/docker-compose
 
         gitlab_backup_upload_enable: yes
         gitlab_backup_upload_type: s3

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -16,6 +16,11 @@ gitlab_email_enabled: no
 gitlab_email_smtp_verify_server_cert: yes
 
 gitlab_backup_upload_enable: no
+gitlab_backup_cron_enable: no
+gitlab_backup_cron_day_of_month: "*"
+gitlab_backup_cron_month: "*"
+gitlab_backup_cron_day_of_week: "*"
+gitlab_backup_cron_docker_compose_path: docker-compose
 
 _volume_owner: 0
 _volume_group: 0

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -15,6 +15,8 @@ gitlab_email_enable: no
 gitlab_email_enabled: no
 gitlab_email_smtp_verify_server_cert: yes
 
+gitlab_backup_upload_enable: no
+
 _volume_owner: 0
 _volume_group: 0
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -16,6 +16,7 @@ gitlab_email_enabled: no
 gitlab_email_smtp_verify_server_cert: yes
 
 gitlab_backup_upload_enable: no
+gitlab_backup_upload_type: s3
 gitlab_backup_cron_enable: no
 gitlab_backup_cron_day_of_month: "*"
 gitlab_backup_cron_month: "*"

--- a/files/gitlab-backup-wrapper
+++ b/files/gitlab-backup-wrapper
@@ -1,0 +1,34 @@
+#!/bin/sh
+
+set -o errexit
+
+project_path=/etc/docker-gitlab
+service_name=gitlab
+
+print_error() {
+    echo "error:" "$@" >&2
+}
+
+container_id=$(
+    docker-compose --project-directory="${project_path}" \
+        ps --quiet ${service_name}
+)
+if [ -z ${container_id} ]; then
+    print_error "GitLab container is stopped"
+    exit 1
+fi
+
+container_id=$(
+    docker ps \
+        --quiet \
+        --filter="id=${container_id}" \
+        --filter="status=running" \
+        --filter="health=healthy"
+)
+if [ -z ${container_id} ]; then
+    print_error "GitLab container is not up and healthy"
+    exit 1
+fi
+
+docker exec ${container_id} \
+    /opt/gitlab/bin/gitlab-backup create CRON=1

--- a/files/gitlab-backup-wrapper
+++ b/files/gitlab-backup-wrapper
@@ -2,6 +2,9 @@
 
 set -o errexit
 
+: ${DOCKER_CMD:=docker}
+: ${DOCKER_COMPOSE_CMD:=docker-compose}
+
 project_path=/etc/docker-gitlab
 service_name=gitlab
 
@@ -10,7 +13,7 @@ print_error() {
 }
 
 container_id=$(
-    docker-compose --project-directory="${project_path}" \
+    ${DOCKER_COMPOSE_CMD} --project-directory="${project_path}" \
         ps --quiet ${service_name}
 )
 if [ -z ${container_id} ]; then
@@ -19,7 +22,7 @@ if [ -z ${container_id} ]; then
 fi
 
 container_id=$(
-    docker ps \
+    ${DOCKER_CMD} ps \
         --quiet \
         --filter="id=${container_id}" \
         --filter="status=running" \
@@ -30,5 +33,5 @@ if [ -z ${container_id} ]; then
     exit 1
 fi
 
-docker exec ${container_id} \
+${DOCKER_CMD} exec ${container_id} \
     /opt/gitlab/bin/gitlab-backup create CRON=1

--- a/molecule/s3_backup/converge.yml
+++ b/molecule/s3_backup/converge.yml
@@ -10,10 +10,7 @@
       import_role:
         name: yabusygin.gitlab
 
-- name: converge S3 mock
-  hosts: s3
-  tasks:
-    - name: install Python
+    - name: install ansible.builtin.pip module dependencies
       apt:
         name:
           - python3-pip
@@ -31,10 +28,9 @@
 
     - name: create bucket for backups
       amazon.aws.aws_s3:
-        s3_url: http://s3.test
-        region: us-east-1
-        bucket: gitlab-backup
-        aws_access_key: local-identity
-        aws_secret_key: local-credential
-        mode: create
         rgw: yes
+        s3_url: "{{ gitlab_backup_upload_s3_endpoint }}"
+        bucket: "{{ gitlab_backup_upload_s3_bucket }}"
+        aws_access_key: "{{ gitlab_backup_upload_s3_access_key_id }}"
+        aws_secret_key: "{{ gitlab_backup_upload_s3_secret_access_key }}"
+        mode: create

--- a/molecule/s3_backup/converge.yml
+++ b/molecule/s3_backup/converge.yml
@@ -1,0 +1,40 @@
+---
+- name: converge gitlab
+  hosts: gitlab
+  tasks:
+    - name: install Docker
+      import_role:
+        name: yabusygin.docker
+
+    - name: install GitLab
+      import_role:
+        name: yabusygin.gitlab
+
+- name: converge S3 mock
+  hosts: s3
+  tasks:
+    - name: install Python
+      apt:
+        name:
+          - python3-pip
+          - python3-setuptools
+          - python3-virtualenv
+        state: present
+        force_apt_get: yes
+        update_cache: yes
+
+    - name: install amazon.aws.aws_s3 module dependencies
+      pip:
+        name:
+          - boto3
+        state: present
+
+    - name: create bucket for backups
+      amazon.aws.aws_s3:
+        s3_url: http://s3.test
+        region: us-east-1
+        bucket: gitlab-backup
+        aws_access_key: local-identity
+        aws_secret_key: local-credential
+        mode: create
+        rgw: yes

--- a/molecule/s3_backup/host_vars/gitlab.yml
+++ b/molecule/s3_backup/host_vars/gitlab.yml
@@ -1,0 +1,17 @@
+---
+ansible_python_interpreter: python3
+
+gitlab_ssh_port: 22022
+
+gitlab_workers: 2
+gitlab_min_threads: 4
+gitlab_max_threads: 4
+
+gitlab_backup_upload_enable: yes
+gitlab_backup_upload_type: s3
+gitlab_backup_upload_s3_endpoint: http://s3.test
+gitlab_backup_upload_s3_region: us-east-1
+gitlab_backup_upload_s3_access_key_id: local-identity
+gitlab_backup_upload_s3_secret_access_key: local-credential
+gitlab_backup_upload_s3_bucket: gitlab-backup
+gitlab_backup_upload_s3_path_style_enable: yes

--- a/molecule/s3_backup/host_vars/gitlab.yml
+++ b/molecule/s3_backup/host_vars/gitlab.yml
@@ -9,9 +9,8 @@ gitlab_max_threads: 4
 
 gitlab_backup_upload_enable: yes
 gitlab_backup_upload_type: s3
-gitlab_backup_upload_s3_endpoint: http://s3.test
-gitlab_backup_upload_s3_region: us-east-1
-gitlab_backup_upload_s3_access_key_id: local-identity
-gitlab_backup_upload_s3_secret_access_key: local-credential
+gitlab_backup_upload_s3_endpoint: http://s3.test:9000
+gitlab_backup_upload_s3_access_key_id: minioadmin
+gitlab_backup_upload_s3_secret_access_key: minioadmin
 gitlab_backup_upload_s3_bucket: gitlab-backup
 gitlab_backup_upload_s3_path_style_enable: yes

--- a/molecule/s3_backup/host_vars/s3.yml
+++ b/molecule/s3_backup/host_vars/s3.yml
@@ -1,3 +1,0 @@
----
-ansible_python_interpreter: python3
-ansible_become_method: su

--- a/molecule/s3_backup/host_vars/s3.yml
+++ b/molecule/s3_backup/host_vars/s3.yml
@@ -1,0 +1,3 @@
+---
+ansible_python_interpreter: python3
+ansible_become_method: su

--- a/molecule/s3_backup/molecule.yml
+++ b/molecule/s3_backup/molecule.yml
@@ -20,8 +20,16 @@ platforms:
         aliases:
           - gitlab.test
   - name: s3
-    image: andrewgaul/s3proxy:sha-b5d090d
+    image: minio/minio:RELEASE.2022-05-19T18-20-59Z
     pre_build_image: true
+    command:
+      - server
+      - /data
+    env:
+      MINIO_BROWSER: "off"
+    volumes:
+      - /data
+    keep_volumes: false
     networks_cli_compatible: yes
     networks:
       - name: test-s3

--- a/molecule/s3_backup/molecule.yml
+++ b/molecule/s3_backup/molecule.yml
@@ -1,0 +1,33 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: docker
+lint: ./lint.sh
+platforms:
+  - name: gitlab
+    image: ${TEST_IMAGE}
+    pre_build_image: true
+    command: ""
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+      - /var/lib/docker
+    keep_volumes: false
+    privileged: true
+    networks_cli_compatible: yes
+    networks:
+      - name: test-s3
+        aliases:
+          - gitlab.test
+  - name: s3
+    image: andrewgaul/s3proxy:sha-b5d090d
+    pre_build_image: true
+    networks_cli_compatible: yes
+    networks:
+      - name: test-s3
+        aliases:
+          - s3.test
+provisioner:
+  name: ansible
+verifier:
+  name: ansible

--- a/molecule/s3_backup/prepare.yml
+++ b/molecule/s3_backup/prepare.yml
@@ -1,6 +1,6 @@
 ---
 - name: prepare
-  hosts: gitlab:s3
+  hosts: gitlab
   gather_facts: false
   tasks:
     - name: install Python 3 for Ansible

--- a/molecule/s3_backup/prepare.yml
+++ b/molecule/s3_backup/prepare.yml
@@ -1,0 +1,9 @@
+---
+- name: prepare
+  hosts: gitlab:s3
+  gather_facts: false
+  tasks:
+    - name: install Python 3 for Ansible
+      raw: test -e /usr/bin/python3 || (apt-get update && apt-get install --yes python3-minimal)
+      become: true
+      changed_when: false

--- a/molecule/s3_backup/requirements.yml
+++ b/molecule/s3_backup/requirements.yml
@@ -1,0 +1,3 @@
+---
+- src: yabusygin.docker
+  version: 3.0.0

--- a/molecule/s3_backup/verify.yml
+++ b/molecule/s3_backup/verify.yml
@@ -23,19 +23,14 @@
           - create
       changed_when: no
 
-- name: check storage
-  hosts: s3
-  gather_facts: no
-  tasks:
     - name: list all keys in gitlab-backup bucket
       amazon.aws.aws_s3:
-        s3_url: http://s3.test
-        region: us-east-1
-        bucket: gitlab-backup
-        aws_access_key: local-identity
-        aws_secret_key: local-credential
-        mode: list
         rgw: yes
+        s3_url: "{{ gitlab_backup_upload_s3_endpoint }}"
+        bucket: "{{ gitlab_backup_upload_s3_bucket }}"
+        aws_access_key: "{{ gitlab_backup_upload_s3_access_key_id }}"
+        aws_secret_key: "{{ gitlab_backup_upload_s3_secret_access_key }}"
+        mode: list
       register: _result
 
     - name: check that backup exists

--- a/molecule/s3_backup/verify.yml
+++ b/molecule/s3_backup/verify.yml
@@ -1,0 +1,45 @@
+---
+- name: trigger backup process
+  hosts: gitlab
+  gather_facts: no
+  tasks:
+    - name: wait until GitLab starts
+      uri:
+        url: http://gitlab.test/
+      register: _result
+      until: _result.status == 200
+      retries: 120
+      delay: 10
+
+    - name: backup GitLab
+      command:
+        argv:
+          - docker-compose
+          - --project-directory=/etc/docker-gitlab
+          - exec
+          - -T
+          - gitlab
+          - gitlab-backup
+          - create
+      changed_when: no
+
+- name: check storage
+  hosts: s3
+  gather_facts: no
+  tasks:
+    - name: list all keys in gitlab-backup bucket
+      amazon.aws.aws_s3:
+        s3_url: http://s3.test
+        region: us-east-1
+        bucket: gitlab-backup
+        aws_access_key: local-identity
+        aws_secret_key: local-credential
+        mode: list
+        rgw: yes
+      register: _result
+
+    - name: check that backup exists
+      assert:
+        that: 
+          - _result.s3_keys|length == 1
+          - _result.s3_keys[0].endswith('_gitlab_backup.tar')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 ansible>=5.0,<6.0
+ansible-lint>=6.0,<6.1
 templtest>=0.2,<0.3
 molecule[docker,lint,test]>=3.6,<3.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 ansible>=5.0,<6.0
 templtest>=0.2,<0.3
-molecule[docker,lint,test]>=3.3,<3.4
+molecule[docker,lint,test]>=3.6,<3.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,7 @@ ansible>=5.0,<6.0
 ansible-lint>=6.0,<6.1
 templtest>=0.2,<0.3
 molecule[docker,lint,test]>=3.6,<3.7
+
+# A workaround for the following issue:
+# https://github.com/ansible-community/molecule/issues/3404
+ansible-compat>=2.0,<2.1

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -70,6 +70,14 @@
   notify:
     - restart GitLab
 
+- name: configure automated backups
+  template:
+    src: gitlab-backup.cron.j2
+    dest: /etc/cron.d/gitlab-backup
+    lstrip_blocks: yes
+    mode: 0644
+  when: gitlab_backup_cron_enable
+
 - name: run GitLab
   docker_compose:
     state: present

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -70,6 +70,12 @@
   notify:
     - restart GitLab
 
+- name: add backup helper script
+  copy:
+    src: gitlab-backup-wrapper
+    dest: /usr/local/bin/gitlab-backup-wrapper
+    mode: 0755
+
 - name: configure automated backups
   template:
     src: gitlab-backup.cron.j2

--- a/templates/gitlab-backup.cron.j2
+++ b/templates/gitlab-backup.cron.j2
@@ -1,1 +1,7 @@
+{% if gitlab_backup_cron_docker_cmd is defined %}
+DOCKER_CMD={{ gitlab_backup_cron_docker_cmd }}
+{% endif %}
+{% if gitlab_backup_cron_docker_compose_cmd is defined %}
+DOCKER_COMPOSE_CMD={{ gitlab_backup_cron_docker_compose_cmd }}
+{% endif %}
 {{ gitlab_backup_cron_minute|mandatory }} {{ gitlab_backup_cron_hour|mandatory }} {{ gitlab_backup_cron_day_of_month }} {{ gitlab_backup_cron_month }} {{ gitlab_backup_cron_day_of_week }} root /usr/local/bin/gitlab-backup-wrapper

--- a/templates/gitlab-backup.cron.j2
+++ b/templates/gitlab-backup.cron.j2
@@ -1,1 +1,1 @@
-{{ gitlab_backup_cron_minute|mandatory }} {{ gitlab_backup_cron_hour|mandatory }} {{ gitlab_backup_cron_day_of_month }} {{ gitlab_backup_cron_month }} {{ gitlab_backup_cron_day_of_week }} root {{ gitlab_backup_cron_docker_compose_path }} --project-directory=/etc/docker-gitlab exec -T gitlab /opt/gitlab/bin/gitlab-backup create CRON=1
+{{ gitlab_backup_cron_minute|mandatory }} {{ gitlab_backup_cron_hour|mandatory }} {{ gitlab_backup_cron_day_of_month }} {{ gitlab_backup_cron_month }} {{ gitlab_backup_cron_day_of_week }} root /usr/local/bin/gitlab-backup-wrapper

--- a/templates/gitlab-backup.cron.j2
+++ b/templates/gitlab-backup.cron.j2
@@ -1,0 +1,1 @@
+{{ gitlab_backup_cron_minute|mandatory }} {{ gitlab_backup_cron_hour|mandatory }} {{ gitlab_backup_cron_day_of_month }} {{ gitlab_backup_cron_month }} {{ gitlab_backup_cron_day_of_week }} root {{ gitlab_backup_cron_docker_compose_path }} --project-directory=/etc/docker-gitlab exec -T gitlab /opt/gitlab/bin/gitlab-backup create CRON=1

--- a/templates/gitlab.rb.j2
+++ b/templates/gitlab.rb.j2
@@ -96,3 +96,25 @@ gitlab_rails['smtp_password'] = '{{ gitlab_email_smtp_user_password }}'
 {% else %}
 gitlab_rails['gitlab_email_enabled'] = false
 {% endif %}
+
+# Backup
+{% if gitlab_backup_keep_time is defined %}
+gitlab_rails['backup_keep_time'] = {{ gitlab_backup_keep_time }}
+{% endif %}
+{% if gitlab_backup_upload_enable %}
+    {% if gitlab_backup_upload_type == 's3' %}
+gitlab_rails['backup_upload_connection'] = {
+  'provider' => 'AWS',
+        {% if gitlab_backup_upload_s3_endpoint is defined %}
+  'endpoint' => '{{ gitlab_backup_upload_s3_endpoint }}',
+        {% endif %}
+  'region' => '{{ gitlab_backup_upload_s3_region }}',
+        {% if gitlab_backup_upload_s3_path_style_enable is defined %}
+  'path_style' => {{ 'true' if gitlab_backup_upload_s3_path_style_enable else 'false' }},
+        {% endif %}
+  'aws_access_key_id' => '{{ gitlab_backup_upload_s3_access_key_id }}',
+  'aws_secret_access_key' => '{{ gitlab_backup_upload_s3_secret_access_key }}'
+}
+gitlab_rails['backup_upload_remote_directory'] = '{{ gitlab_backup_upload_s3_bucket }}'
+    {% endif %}
+{% endif %}

--- a/templates/gitlab.rb.j2
+++ b/templates/gitlab.rb.j2
@@ -114,9 +114,9 @@ gitlab_rails['backup_upload_connection'] = {
         {% if gitlab_backup_upload_s3_path_style_enable is defined %}
   'path_style' => {{ 'true' if gitlab_backup_upload_s3_path_style_enable else 'false' }},
         {% endif %}
-  'aws_access_key_id' => '{{ gitlab_backup_upload_s3_access_key_id }}',
-  'aws_secret_access_key' => '{{ gitlab_backup_upload_s3_secret_access_key }}'
+  'aws_access_key_id' => '{{ gitlab_backup_upload_s3_access_key_id|mandatory }}',
+  'aws_secret_access_key' => '{{ gitlab_backup_upload_s3_secret_access_key|mandatory }}'
 }
-gitlab_rails['backup_upload_remote_directory'] = '{{ gitlab_backup_upload_s3_bucket }}'
+gitlab_rails['backup_upload_remote_directory'] = '{{ gitlab_backup_upload_s3_bucket|mandatory }}'
     {% endif %}
 {% endif %}

--- a/templates/gitlab.rb.j2
+++ b/templates/gitlab.rb.j2
@@ -108,7 +108,9 @@ gitlab_rails['backup_upload_connection'] = {
         {% if gitlab_backup_upload_s3_endpoint is defined %}
   'endpoint' => '{{ gitlab_backup_upload_s3_endpoint }}',
         {% endif %}
+        {% if gitlab_backup_upload_s3_region is defined %}
   'region' => '{{ gitlab_backup_upload_s3_region }}',
+        {% endif %}
         {% if gitlab_backup_upload_s3_path_style_enable is defined %}
   'path_style' => {{ 'true' if gitlab_backup_upload_s3_path_style_enable else 'false' }},
         {% endif %}

--- a/templates_tests/config/backup/keep_time/gitlab.rb
+++ b/templates_tests/config/backup/keep_time/gitlab.rb
@@ -5,9 +5,6 @@ registry_external_url 'http://gitlab.test:5050'
 # HTTPS
 
 # Application server
-puma['worker_processes'] = 3
-puma['min_threads'] = 1
-puma['max_threads'] = 4
 
 # Monitoring
 
@@ -15,3 +12,4 @@ puma['max_threads'] = 4
 gitlab_rails['gitlab_email_enabled'] = false
 
 # Backup
+gitlab_rails['backup_keep_time'] = 604800

--- a/templates_tests/config/backup/keep_time/inventory.yml
+++ b/templates_tests/config/backup/keep_time/inventory.yml
@@ -1,0 +1,2 @@
+---
+gitlab_backup_keep_time: 604800

--- a/templates_tests/config/backup/upload/s3/aws/gitlab.rb
+++ b/templates_tests/config/backup/upload/s3/aws/gitlab.rb
@@ -1,0 +1,21 @@
+# URL
+external_url 'http://gitlab.test'
+registry_external_url 'http://gitlab.test:5050'
+
+# HTTPS
+
+# Application server
+
+# Monitoring
+
+# Outgoing emails
+gitlab_rails['gitlab_email_enabled'] = false
+
+# Backup
+gitlab_rails['backup_upload_connection'] = {
+  'provider' => 'AWS',
+  'region' => 'eu-west-1',
+  'aws_access_key_id' => 'AKIAKIAKI',
+  'aws_secret_access_key' => 'secret123'
+}
+gitlab_rails['backup_upload_remote_directory'] = 'my.s3.bucket'

--- a/templates_tests/config/backup/upload/s3/aws/inventory.yml
+++ b/templates_tests/config/backup/upload/s3/aws/inventory.yml
@@ -1,0 +1,7 @@
+---
+gitlab_backup_upload_enable: yes
+gitlab_backup_upload_type: s3
+gitlab_backup_upload_s3_region: eu-west-1
+gitlab_backup_upload_s3_access_key_id: AKIAKIAKI
+gitlab_backup_upload_s3_secret_access_key: secret123
+gitlab_backup_upload_s3_bucket: my.s3.bucket

--- a/templates_tests/config/backup/upload/s3/digital_ocean/gitlab.rb
+++ b/templates_tests/config/backup/upload/s3/digital_ocean/gitlab.rb
@@ -1,0 +1,22 @@
+# URL
+external_url 'http://gitlab.test'
+registry_external_url 'http://gitlab.test:5050'
+
+# HTTPS
+
+# Application server
+
+# Monitoring
+
+# Outgoing emails
+gitlab_rails['gitlab_email_enabled'] = false
+
+# Backup
+gitlab_rails['backup_upload_connection'] = {
+  'provider' => 'AWS',
+  'endpoint' => 'https://ams3.digitaloceanspaces.com',
+  'region' => 'ams3',
+  'aws_access_key_id' => 'AKIAKIAKI',
+  'aws_secret_access_key' => 'secret123'
+}
+gitlab_rails['backup_upload_remote_directory'] = 'my.s3.bucket'

--- a/templates_tests/config/backup/upload/s3/digital_ocean/inventory.yml
+++ b/templates_tests/config/backup/upload/s3/digital_ocean/inventory.yml
@@ -1,0 +1,8 @@
+---
+gitlab_backup_upload_enable: yes
+gitlab_backup_upload_type: s3
+gitlab_backup_upload_s3_endpoint: https://ams3.digitaloceanspaces.com
+gitlab_backup_upload_s3_region: ams3
+gitlab_backup_upload_s3_access_key_id: AKIAKIAKI
+gitlab_backup_upload_s3_secret_access_key: secret123
+gitlab_backup_upload_s3_bucket: my.s3.bucket

--- a/templates_tests/config/backup/upload/s3/minio/gitlab.rb
+++ b/templates_tests/config/backup/upload/s3/minio/gitlab.rb
@@ -14,7 +14,7 @@ gitlab_rails['gitlab_email_enabled'] = false
 # Backup
 gitlab_rails['backup_upload_connection'] = {
   'provider' => 'AWS',
-  'region' => 'eu-west-1',
+  'endpoint' => 'https://minio.test',
   'path_style' => true,
   'aws_access_key_id' => 'AKIAKIAKI',
   'aws_secret_access_key' => 'secret123'

--- a/templates_tests/config/backup/upload/s3/minio/inventory.yml
+++ b/templates_tests/config/backup/upload/s3/minio/inventory.yml
@@ -1,7 +1,7 @@
 ---
 gitlab_backup_upload_enable: yes
 gitlab_backup_upload_type: s3
-gitlab_backup_upload_s3_region: eu-west-1
+gitlab_backup_upload_s3_endpoint: https://minio.test
 gitlab_backup_upload_s3_access_key_id: AKIAKIAKI
 gitlab_backup_upload_s3_secret_access_key: secret123
 gitlab_backup_upload_s3_bucket: my.s3.bucket

--- a/templates_tests/config/backup/upload/s3/path_style/gitlab.rb
+++ b/templates_tests/config/backup/upload/s3/path_style/gitlab.rb
@@ -1,0 +1,22 @@
+# URL
+external_url 'http://gitlab.test'
+registry_external_url 'http://gitlab.test:5050'
+
+# HTTPS
+
+# Application server
+
+# Monitoring
+
+# Outgoing emails
+gitlab_rails['gitlab_email_enabled'] = false
+
+# Backup
+gitlab_rails['backup_upload_connection'] = {
+  'provider' => 'AWS',
+  'region' => 'eu-west-1',
+  'path_style' => true,
+  'aws_access_key_id' => 'AKIAKIAKI',
+  'aws_secret_access_key' => 'secret123'
+}
+gitlab_rails['backup_upload_remote_directory'] = 'my.s3.bucket'

--- a/templates_tests/config/backup/upload/s3/path_style/inventory.yml
+++ b/templates_tests/config/backup/upload/s3/path_style/inventory.yml
@@ -1,0 +1,8 @@
+---
+gitlab_backup_upload_enable: yes
+gitlab_backup_upload_type: s3
+gitlab_backup_upload_s3_region: eu-west-1
+gitlab_backup_upload_s3_access_key_id: AKIAKIAKI
+gitlab_backup_upload_s3_secret_access_key: secret123
+gitlab_backup_upload_s3_bucket: my.s3.bucket
+gitlab_backup_upload_s3_path_style_enable: yes

--- a/templates_tests/config/default/gitlab.rb
+++ b/templates_tests/config/default/gitlab.rb
@@ -10,3 +10,5 @@ registry_external_url 'http://gitlab.test:5050'
 
 # Outgoing emails
 gitlab_rails['gitlab_email_enabled'] = false
+
+# Backup

--- a/templates_tests/config/deprecated_unicorn_workers/gitlab.rb
+++ b/templates_tests/config/deprecated_unicorn_workers/gitlab.rb
@@ -11,3 +11,5 @@ unicorn['worker_processes'] = 3
 
 # Outgoing emails
 gitlab_rails['gitlab_email_enabled'] = false
+
+# Backup

--- a/templates_tests/config/email/deprecated/gitlab.rb
+++ b/templates_tests/config/email/deprecated/gitlab.rb
@@ -22,3 +22,5 @@ gitlab_rails['smtp_openssl_verify_mode'] = 'peer'
 gitlab_rails['smtp_authentication'] = 'plain'
 gitlab_rails['smtp_user_name'] = 'gitlab'
 gitlab_rails['smtp_password'] = 'Pa$$w0rD'
+
+# Backup

--- a/templates_tests/config/email/insecure_transport/gitlab.rb
+++ b/templates_tests/config/email/insecure_transport/gitlab.rb
@@ -21,3 +21,5 @@ gitlab_rails['smtp_enable_starttls_auto'] = false
 gitlab_rails['smtp_authentication'] = 'login'
 gitlab_rails['smtp_user_name'] = 'gitlab'
 gitlab_rails['smtp_password'] = 'Pa$$w0rD'
+
+# Backup

--- a/templates_tests/config/email/private_ca/gitlab.rb
+++ b/templates_tests/config/email/private_ca/gitlab.rb
@@ -23,3 +23,5 @@ gitlab_rails['smtp_ca_file'] = '/etc/ssl/certs/smtp.crt.pem'
 gitlab_rails['smtp_authentication'] = 'plain'
 gitlab_rails['smtp_user_name'] = 'gitlab'
 gitlab_rails['smtp_password'] = 'Pa$$w0rD'
+
+# Backup

--- a/templates_tests/config/email/starttls/gitlab.rb
+++ b/templates_tests/config/email/starttls/gitlab.rb
@@ -22,3 +22,5 @@ gitlab_rails['smtp_openssl_verify_mode'] = 'peer'
 gitlab_rails['smtp_authentication'] = 'login'
 gitlab_rails['smtp_user_name'] = 'gitlab'
 gitlab_rails['smtp_password'] = 'Pa$$w0rD'
+
+# Backup

--- a/templates_tests/config/email/tls/gitlab.rb
+++ b/templates_tests/config/email/tls/gitlab.rb
@@ -22,3 +22,5 @@ gitlab_rails['smtp_openssl_verify_mode'] = 'peer'
 gitlab_rails['smtp_authentication'] = 'plain'
 gitlab_rails['smtp_user_name'] = 'gitlab'
 gitlab_rails['smtp_password'] = 'Pa$$w0rD'
+
+# Backup

--- a/templates_tests/config/email/unverified_cert/gitlab.rb
+++ b/templates_tests/config/email/unverified_cert/gitlab.rb
@@ -22,3 +22,5 @@ gitlab_rails['smtp_openssl_verify_mode'] = 'none'
 gitlab_rails['smtp_authentication'] = 'plain'
 gitlab_rails['smtp_user_name'] = 'gitlab'
 gitlab_rails['smtp_password'] = 'Pa$$w0rD'
+
+# Backup

--- a/templates_tests/config/force_unicorn/gitlab.rb
+++ b/templates_tests/config/force_unicorn/gitlab.rb
@@ -13,3 +13,5 @@ unicorn['worker_processes'] = 3
 
 # Outgoing emails
 gitlab_rails['gitlab_email_enabled'] = false
+
+# Backup

--- a/templates_tests/config/https/letsencrypt/gitlab.rb
+++ b/templates_tests/config/https/letsencrypt/gitlab.rb
@@ -11,3 +11,5 @@ letsencrypt['enable'] = true
 
 # Outgoing emails
 gitlab_rails['gitlab_email_enabled'] = false
+
+# Backup

--- a/templates_tests/config/https/manual/gitlab.rb
+++ b/templates_tests/config/https/manual/gitlab.rb
@@ -11,3 +11,5 @@ letsencrypt['enable'] = false
 
 # Outgoing emails
 gitlab_rails['gitlab_email_enabled'] = false
+
+# Backup

--- a/templates_tests/config/monitoring_whitelist/multiple_entries/gitlab.rb
+++ b/templates_tests/config/monitoring_whitelist/multiple_entries/gitlab.rb
@@ -11,3 +11,5 @@ gitlab_rails['monitoring_whitelist'] = ['127.0.0.0/8', '192.168.0.10']
 
 # Outgoing emails
 gitlab_rails['gitlab_email_enabled'] = false
+
+# Backup

--- a/templates_tests/config/monitoring_whitelist/single_entry/gitlab.rb
+++ b/templates_tests/config/monitoring_whitelist/single_entry/gitlab.rb
@@ -11,3 +11,5 @@ gitlab_rails['monitoring_whitelist'] = ['127.0.0.0/8']
 
 # Outgoing emails
 gitlab_rails['gitlab_email_enabled'] = false
+
+# Backup

--- a/templates_tests/config/url/gitlab.rb
+++ b/templates_tests/config/url/gitlab.rb
@@ -11,3 +11,5 @@ gitlab_rails['gitlab_shell_ssh_port'] = 2222
 
 # Outgoing emails
 gitlab_rails['gitlab_email_enabled'] = false
+
+# Backup

--- a/templates_tests/cron/custom/gitlab-backup
+++ b/templates_tests/cron/custom/gitlab-backup
@@ -1,0 +1,1 @@
+0 1 2 3 4 root docker-compose --project-directory=/etc/docker-gitlab exec -T gitlab /opt/gitlab/bin/gitlab-backup create CRON=1

--- a/templates_tests/cron/custom/gitlab-backup
+++ b/templates_tests/cron/custom/gitlab-backup
@@ -1,1 +1,1 @@
-0 1 2 3 4 root docker-compose --project-directory=/etc/docker-gitlab exec -T gitlab /opt/gitlab/bin/gitlab-backup create CRON=1
+0 1 2 3 4 root /usr/local/bin/gitlab-backup-wrapper

--- a/templates_tests/cron/custom/gitlab-backup
+++ b/templates_tests/cron/custom/gitlab-backup
@@ -1,1 +1,3 @@
+DOCKER_CMD=/usr/bin/docker
+DOCKER_COMPOSE_CMD=/usr/local/bin/docker-compose
 0 1 2 3 4 root /usr/local/bin/gitlab-backup-wrapper

--- a/templates_tests/cron/custom/inventory.yml
+++ b/templates_tests/cron/custom/inventory.yml
@@ -1,0 +1,7 @@
+---
+gitlab_backup_cron_enable: yes
+gitlab_backup_cron_minute: 0
+gitlab_backup_cron_hour: 1
+gitlab_backup_cron_day_of_month: 2
+gitlab_backup_cron_month: 3
+gitlab_backup_cron_day_of_week: 4

--- a/templates_tests/cron/custom/inventory.yml
+++ b/templates_tests/cron/custom/inventory.yml
@@ -5,3 +5,5 @@ gitlab_backup_cron_hour: 1
 gitlab_backup_cron_day_of_month: 2
 gitlab_backup_cron_month: 3
 gitlab_backup_cron_day_of_week: 4
+gitlab_backup_cron_docker_cmd: /usr/bin/docker
+gitlab_backup_cron_docker_compose_cmd: /usr/local/bin/docker-compose

--- a/templates_tests/cron/default/gitlab-backup
+++ b/templates_tests/cron/default/gitlab-backup
@@ -1,1 +1,1 @@
-0 2 * * * root docker-compose --project-directory=/etc/docker-gitlab exec -T gitlab /opt/gitlab/bin/gitlab-backup create CRON=1
+0 2 * * * root /usr/local/bin/gitlab-backup-wrapper

--- a/templates_tests/cron/default/gitlab-backup
+++ b/templates_tests/cron/default/gitlab-backup
@@ -1,0 +1,1 @@
+0 2 * * * root docker-compose --project-directory=/etc/docker-gitlab exec -T gitlab /opt/gitlab/bin/gitlab-backup create CRON=1

--- a/templates_tests/cron/default/inventory.yml
+++ b/templates_tests/cron/default/inventory.yml
@@ -1,0 +1,4 @@
+---
+gitlab_backup_cron_enable: yes
+gitlab_backup_cron_minute: 0
+gitlab_backup_cron_hour: 2

--- a/templates_tests/test.yml
+++ b/templates_tests/test.yml
@@ -126,11 +126,11 @@ tests:
       inventory: config/backup/upload/s3/digital_ocean/inventory.yml
     expected_result: config/backup/upload/s3/digital_ocean/gitlab.rb
 
-  - name: use path-style requests to access S3
+  - name: upload backups to MinIO
     template: gitlab.rb.j2
     variables:
-      inventory: config/backup/upload/s3/path_style/inventory.yml
-    expected_result: config/backup/upload/s3/path_style/gitlab.rb
+      inventory: config/backup/upload/s3/minio/inventory.yml
+    expected_result: config/backup/upload/s3/minio/gitlab.rb
 
   - name: cronjob for automated daily backups (default)
     template: gitlab-backup.cron.j2

--- a/templates_tests/test.yml
+++ b/templates_tests/test.yml
@@ -107,3 +107,27 @@ tests:
     variables:
       inventory: config/email/private_ca/inventory.yml
     expected_result: config/email/private_ca/gitlab.rb
+
+  - name: backup keep time
+    template: gitlab.rb.j2
+    variables:
+      inventory: config/backup/keep_time/inventory.yml
+    expected_result: config/backup/keep_time/gitlab.rb
+
+  - name: upload backups to AWS S3
+    template: gitlab.rb.j2
+    variables:
+      inventory: config/backup/upload/s3/aws/inventory.yml
+    expected_result: config/backup/upload/s3/aws/gitlab.rb
+
+  - name: upload backups to Digital Ocean Spaces
+    template: gitlab.rb.j2
+    variables:
+      inventory: config/backup/upload/s3/digital_ocean/inventory.yml
+    expected_result: config/backup/upload/s3/digital_ocean/gitlab.rb
+
+  - name: use path-style requests to access S3
+    template: gitlab.rb.j2
+    variables:
+      inventory: config/backup/upload/s3/path_style/inventory.yml
+    expected_result: config/backup/upload/s3/path_style/gitlab.rb

--- a/templates_tests/test.yml
+++ b/templates_tests/test.yml
@@ -131,3 +131,15 @@ tests:
     variables:
       inventory: config/backup/upload/s3/path_style/inventory.yml
     expected_result: config/backup/upload/s3/path_style/gitlab.rb
+
+  - name: cronjob for automated daily backups (default)
+    template: gitlab-backup.cron.j2
+    variables:
+      inventory: cron/default/inventory.yml
+    expected_result: cron/default/gitlab-backup
+
+  - name: cronjob for automated backups (custom day and month)
+    template: gitlab-backup.cron.j2
+    variables:
+      inventory: cron/custom/inventory.yml
+    expected_result: cron/custom/gitlab-backup


### PR DESCRIPTION
Implemented the following features:

* cron job for periodic backup automation 
* uploading backups to remote S3 compatible storage
* limiting lifetime of backups at local storage

Cron job is configured with the following variables:

* `gitlab_backup_cron_enable`
* `gitlab_backup_cron_minute`
* `gitlab_backup_cron_hour`
* `gitlab_backup_cron_day_of_month`
* `gitlab_backup_cron_month`
* `gitlab_backup_cron_day_of_week`
* `gitlab_backup_cron_docker_cmd`
* `gitlab_backup_cron_docker_compose_cmd`

Uploading to remote storage is configured with the following variables:

* `gitlab_backup_upload_enable`
* `gitlab_backup_upload_type`
* `gitlab_backup_upload_s3_region`
* `gitlab_backup_upload_s3_bucket`
* `gitlab_backup_upload_s3_access_key_id`
* `gitlab_backup_upload_s3_secret_access_key`
* `gitlab_backup_upload_s3_endpoint`
* `gitlab_backup_upload_s3_path_style_enable`

Local backup lifetime is limited with `gitlab_backup_keep_time` variable.

Closes #69 