### PR TITLE
Discontinue support of Debian 9

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,6 @@ jobs:
     strategy:
       matrix:
         image:
-          - "geerlingguy/docker-debian9-ansible:latest"
           - "geerlingguy/docker-debian10-ansible:latest"
           - "geerlingguy/docker-ubuntu1804-ansible:latest"
           - "geerlingguy/docker-ubuntu2004-ansible:latest"

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -10,7 +10,6 @@ galaxy_info:
     - name: Debian
       versions:
         - buster
-        - stretch
     - name: Ubuntu
       versions:
         - xenial


### PR DESCRIPTION
Debian 9 [reached][1] the end of life.

[1]: https://wiki.debian.org/DebianReleases