### PR TITLE
Update supported platforms

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,8 +32,9 @@ jobs:
       matrix:
         image:
           - "geerlingguy/docker-debian10-ansible:latest"
-          - "geerlingguy/docker-ubuntu1804-ansible:latest"
+          - "geerlingguy/docker-debian11-ansible:latest"
           - "geerlingguy/docker-ubuntu2004-ansible:latest"
+          - "geerlingguy/docker-ubuntu2204-ansible:latest"
         scenario:
           - default
           - userns_remap

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -10,10 +10,11 @@ galaxy_info:
     - name: Debian
       versions:
         - buster
+        - bullseye
     - name: Ubuntu
       versions:
-        - xenial
         - focal
+        - jammy
   galaxy_tags:
     - docker
     - git

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -13,5 +13,5 @@
     - name: install HTTPie
       ansible.builtin.pip:
         name:
-          - httpie<2.0.0
+          - httpie
         state: present

--- a/molecule/https/converge.yml
+++ b/molecule/https/converge.yml
@@ -19,5 +19,5 @@
     - name: install HTTPie
       ansible.builtin.pip:
         name:
-          - httpie<2.0.0
+          - httpie
         state: present

--- a/molecule/smtp/converge.yml
+++ b/molecule/smtp/converge.yml
@@ -13,7 +13,7 @@
     - name: install HTTPie
       ansible.builtin.pip:
         name:
-          - httpie<2.0.0
+          - httpie
         state: present
 
 - name: converge smtp

--- a/molecule/userns_remap/converge.yml
+++ b/molecule/userns_remap/converge.yml
@@ -13,5 +13,5 @@
     - name: install HTTPie
       ansible.builtin.pip:
         name:
-          - httpie<2.0.0
+          - httpie
         state: present


### PR DESCRIPTION
Support the last two Debian/Ubuntu versions:
 
- Debian: 10 (Buster) -> 10, 11 (Bullseye)
- Ubuntu: 18.04 (Xenial), 20.04 (Focal) -> 20.04, 22.04 (Jammy)