### PR TITLE
Unify formatting of CLI arguments

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,7 +56,7 @@ jobs:
         run: python -m pip install --requirement=requirements.txt
 
       - name: run Molecule tests
-        run: molecule test --scenario-name ${TEST_SCENARIO}
+        run: molecule test --scenario-name=${TEST_SCENARIO}
         env:
           TEST_IMAGE: ${{ matrix.image }}
           TEST_SCENARIO: ${{ matrix.scenario }}


### PR DESCRIPTION
Prefer GNU long options syntax to specify CLI arguments.