### PR TITLE
Use yabusygin.docker version 4.0.5

### DIFF
--- a/molecule/default/requirements.yml
+++ b/molecule/default/requirements.yml
@@ -1,4 +1,4 @@
 ---
 roles:
   - name: yabusygin.docker
-    version: 4.0.4
+    version: 4.0.5

--- a/molecule/https/requirements.yml
+++ b/molecule/https/requirements.yml
@@ -1,4 +1,4 @@
 ---
 roles:
   - name: yabusygin.docker
-    version: 4.0.4
+    version: 4.0.5

--- a/molecule/s3_backup/requirements.yml
+++ b/molecule/s3_backup/requirements.yml
@@ -1,4 +1,4 @@
 ---
 roles:
   - name: yabusygin.docker
-    version: 4.0.4
+    version: 4.0.5

--- a/molecule/smtp/requirements.yml
+++ b/molecule/smtp/requirements.yml
@@ -1,4 +1,4 @@
 ---
 roles:
   - name: yabusygin.docker
-    version: 4.0.4
+    version: 4.0.5

--- a/molecule/userns_remap/requirements.yml
+++ b/molecule/userns_remap/requirements.yml
@@ -1,4 +1,4 @@
 ---
 roles:
   - name: yabusygin.docker
-    version: 4.0.4
+    version: 4.0.5


### PR DESCRIPTION
Molecule scenarios have been updated to use the `yabusygin.docker` role version 4.0.5.