### PR TITLE
Default to Docker Compose plugin instead of standalone binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -426,7 +426,7 @@ Variable reference:
     invoke Docker Engine. Default: `docker`.
 
 *   `gitlab_backup_cron_docker_compose_cmd` -- command that backup cron job uses
-    to invoke Docker Compose. Default: `docker-compose`.
+    to invoke Docker Compose. Default: `docker compose`.
 
 [Crontab5]: https://man7.org/linux/man-pages/man5/crontab.5.html
 

--- a/files/gitlab-backup-wrapper
+++ b/files/gitlab-backup-wrapper
@@ -3,7 +3,7 @@
 set -o errexit
 
 : ${DOCKER_CMD:=docker}
-: ${DOCKER_COMPOSE_CMD:=docker-compose}
+: ${DOCKER_COMPOSE_CMD:=docker compose}
 
 project_path=/etc/docker-gitlab
 service_name=gitlab

--- a/molecule/s3_backup/host_vars/gitlab.yml
+++ b/molecule/s3_backup/host_vars/gitlab.yml
@@ -14,4 +14,3 @@ gitlab_backup_upload_s3_access_key_id: minioadmin
 gitlab_backup_upload_s3_secret_access_key: minioadmin
 gitlab_backup_upload_s3_bucket: gitlab-backup
 gitlab_backup_upload_s3_path_style_enable: yes
-gitlab_backup_cron_docker_compose_cmd: docker compose


### PR DESCRIPTION
Default to newer `docker compose` command (instead of `docker-compose`).