### PR TITLE
Use "no" instead of "false" boolean literals

### DIFF
--- a/tasks/set-volume-owner.yml
+++ b/tasks/set-volume-owner.yml
@@ -6,7 +6,7 @@
   args:
     executable: /bin/bash
   register: _range_begin
-  changed_when: false
+  changed_when: no
 
 - name: set owner ID for files that are mounted to container
   ansible.builtin.set_fact:
@@ -19,7 +19,7 @@
   args:
     executable: /bin/bash
   register: _range_begin
-  changed_when: false
+  changed_when: no
 
 - name: set group ID for files that are mounted to container
   ansible.builtin.set_fact:


### PR DESCRIPTION
Fix boolean literals formatting in Ansible playbooks.