### PR TITLE
Use "_gitlab_" prefix for names of private vars

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -23,7 +23,7 @@ gitlab_backup_cron_month: "*"
 gitlab_backup_cron_day_of_week: "*"
 gitlab_backup_cron_docker_compose_path: docker-compose
 
-_volume_owner: 0
-_volume_group: 0
+_gitlab_volume_owner: 0
+_gitlab_volume_group: 0
 
-_url_scheme: "{% if gitlab_https_enable %}https{% else %}http{% endif %}"
+_gitlab_url_scheme: "{% if gitlab_https_enable %}https{% else %}http{% endif %}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -14,8 +14,8 @@
     src: gitlab.rb.j2
     dest: /etc/docker-gitlab/gitlab.rb
     lstrip_blocks: yes
-    owner: "{{ _volume_owner }}"
-    group: "{{ _volume_group }}"
+    owner: "{{ _gitlab_volume_owner }}"
+    group: "{{ _gitlab_volume_group }}"
     mode: 0600
   notify:
     - restart GitLab
@@ -24,16 +24,16 @@
   ansible.builtin.file:
     path: /etc/docker-gitlab/https
     state: directory
-    owner: "{{ _volume_owner }}"
-    group: "{{ _volume_group }}"
+    owner: "{{ _gitlab_volume_owner }}"
+    group: "{{ _gitlab_volume_group }}"
     mode: 0700
 
 - name: upload HTTPS key
   ansible.builtin.copy:
     src: "{{ gitlab_https_key }}"
     dest: "/etc/docker-gitlab/https/{{ gitlab_hostname }}.key"
-    owner: "{{ _volume_owner }}"
-    group: "{{ _volume_group }}"
+    owner: "{{ _gitlab_volume_owner }}"
+    group: "{{ _gitlab_volume_group }}"
     mode: 0600
   when: gitlab_https_key is defined
   notify:
@@ -43,8 +43,8 @@
   ansible.builtin.copy:
     src: "{{ gitlab_https_cert }}"
     dest: "/etc/docker-gitlab/https/{{ gitlab_hostname }}.crt"
-    owner: "{{ _volume_owner }}"
-    group: "{{ _volume_group }}"
+    owner: "{{ _gitlab_volume_owner }}"
+    group: "{{ _gitlab_volume_group }}"
     mode: 0600
   when: gitlab_https_cert is defined
   notify:
@@ -54,8 +54,8 @@
   ansible.builtin.copy:
     src: "{{ gitlab_email_smtp_ca_cert }}"
     dest: /etc/docker-gitlab/smtp.crt.pem
-    owner: "{{ _volume_owner }}"
-    group: "{{ _volume_group }}"
+    owner: "{{ _gitlab_volume_owner }}"
+    group: "{{ _gitlab_volume_group }}"
     mode: 0600
   when: gitlab_email_smtp_ca_cert is defined
   notify:

--- a/tasks/set-volume-owner.yml
+++ b/tasks/set-volume-owner.yml
@@ -10,7 +10,7 @@
 
 - name: set owner ID for files that are mounted to container
   ansible.builtin.set_fact:
-    _volume_owner: "{{ _range_begin.stdout | int + _volume_owner }}"
+    _gitlab_volume_owner: "{{ _range_begin.stdout | int + _gitlab_volume_owner }}"
 
 - name: get subordinate GID range begining of Docker user
   ansible.builtin.shell: |
@@ -23,4 +23,4 @@
 
 - name: set group ID for files that are mounted to container
   ansible.builtin.set_fact:
-    _volume_group: "{{ _range_begin.stdout | int + _volume_group }}"
+    _gitlab_volume_group: "{{ _range_begin.stdout | int + _gitlab_volume_group }}"

--- a/templates/gitlab.rb.j2
+++ b/templates/gitlab.rb.j2
@@ -1,10 +1,10 @@
 # URL
 {% if gitlab_web_port is defined %}
-external_url '{{ _url_scheme }}://{{ gitlab_hostname }}:{{ gitlab_web_port }}'
+external_url '{{ _gitlab_url_scheme }}://{{ gitlab_hostname }}:{{ gitlab_web_port }}'
 {% else %}
-external_url '{{ _url_scheme }}://{{ gitlab_hostname }}'
+external_url '{{ _gitlab_url_scheme }}://{{ gitlab_hostname }}'
 {% endif %}
-registry_external_url '{{ _url_scheme }}://{{ gitlab_hostname }}:{{ gitlab_registry_port }}'
+registry_external_url '{{ _gitlab_url_scheme }}://{{ gitlab_hostname }}:{{ gitlab_registry_port }}'
 {% if gitlab_ssh_port is defined %}
 gitlab_rails['gitlab_shell_ssh_port'] = {{ gitlab_ssh_port }}
 {% endif %}


### PR DESCRIPTION
This PR unifies variable naming.