### PR TITLE
Update to version 4.0.6 of "yabusygin.docker" role

### DIFF
--- a/molecule/default/requirements.yml
+++ b/molecule/default/requirements.yml
@@ -1,4 +1,4 @@
 ---
 roles:
   - name: yabusygin.docker
-    version: 4.0.5
+    version: 4.0.6

--- a/molecule/https/requirements.yml
+++ b/molecule/https/requirements.yml
@@ -1,4 +1,4 @@
 ---
 roles:
   - name: yabusygin.docker
-    version: 4.0.5
+    version: 4.0.6

--- a/molecule/s3_backup/requirements.yml
+++ b/molecule/s3_backup/requirements.yml
@@ -1,4 +1,4 @@
 ---
 roles:
   - name: yabusygin.docker
-    version: 4.0.5
+    version: 4.0.6

--- a/molecule/smtp/requirements.yml
+++ b/molecule/smtp/requirements.yml
@@ -1,4 +1,4 @@
 ---
 roles:
   - name: yabusygin.docker
-    version: 4.0.5
+    version: 4.0.6

--- a/molecule/userns_remap/requirements.yml
+++ b/molecule/userns_remap/requirements.yml
@@ -1,4 +1,4 @@
 ---
 roles:
   - name: yabusygin.docker
-    version: 4.0.5
+    version: 4.0.6


### PR DESCRIPTION
The [yabusygin.docker][1] role is used by Molecule tests. The tests have been updated to use version 4.0.6 of the role.

[1]: https://github.com/yabusygin/ansible-role-docker